### PR TITLE
LH-3595 send json object in request instead of json string

### DIFF
--- a/lib/webhook_system/encoder.rb
+++ b/lib/webhook_system/encoder.rb
@@ -10,9 +10,9 @@ module WebhookSystem
     # @return [String] The encoded string payload (its a JSON string)
     def self.encode(secret_string, payload, format:)
       response_hash = Payload.encode(payload, secret: secret_string, format: format)
-      payload_string = JSON.generate(response_hash)
-      signature = hub_signature(payload_string, secret_string)
-      [payload_string, { 'X-Hub-Signature' => signature, 'Content-Type' => content_type_for_format(format) }]
+      payload_json = JSON.parse(JSON.generate(response_hash))
+      signature = hub_signature(payload_json, secret_string)
+      [payload_json, { 'X-Hub-Signature' => signature, 'Content-Type' => content_type_for_format(format) }]
     end
 
     # Given a secret string, and an encrypted payload, unwrap it, bas64 decode it


### PR DESCRIPTION
We are changing data format for request payload from json string to json object.

previous request payload format example : 

`"{\"event_name\"=>\"assessment_started\", \"event_id\"=>\"cc57cb4a-d9a0-4961-a895-232efd500387\", \"data\"=>{\"assessment\"=>{\"id\"=>703, \"name\"=>\"Test HBRI\"}, \"evaluator\"=>{\"id\"=>34621, \"name\"=>\"buntys ttkk\"}, \"subject\"=>{\"id\"=>34621, \"name\"=>\"buntys ttkk\"}, \"project\"=>{\"id\"=>1938, \"name\"=>\"aug sept\"}, \"client\"=>{\"id\"=>1937, \"name\"=>\"QA sept 2022 testing\"}, \"campaign\"=>{\"id\"=>10536, \"name\"=>\"ITR 2022 Common\"}, \"event_time\"=>\"2023-01-31T21:10:23.975+05:30\"}}"`

Changed as json object:

`{"event_name"=>"assessment_started", "event_id"=>"cc57cb4a-d9a0-4961-a895-232efd500387", "data"=>{"assessment"=>{"id"=>703, "name"=>"Test HBRI"}, "evaluator"=>{"id"=>34621, "name"=>"buntys ttkk"}, "subject"=>{"id"=>34621, "name"=>"buntys ttkk"}, "project"=>{"id"=>1938, "name"=>"aug sept"}, "client"=>{"id"=>1937, "name"=>"QA sept 2022 testing"}, "campaign"=>{"id"=>10536, "name"=>"ITR 2022 Common"}, "event_time"=>"2023-01-31T21:10:23.975+05:30"}}`